### PR TITLE
Bugfix: Chart should display bitcoin, not sats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ btcd-conn.json
 elmd-conn.json
 prevent_mining
 .idea
+build/
+dist/

--- a/src/cryptoadvance/specterext/stacktrack/helpers/core.py
+++ b/src/cryptoadvance/specterext/stacktrack/helpers/core.py
@@ -1,6 +1,9 @@
 from enum import Enum
 
 
+SATS_PER_BTC = 100_000_000
+
+
 class Interval(Enum):
     HOUR = 1
     DAY = 2

--- a/src/cryptoadvance/specterext/stacktrack/helpers/count.py
+++ b/src/cryptoadvance/specterext/stacktrack/helpers/count.py
@@ -5,12 +5,10 @@ from cryptoadvance.specter.wallet import Wallet
 import pandas as pd
 
 from . import dtutil
-from .core import Interval
+from .core import *
 
 
 logger = logging.getLogger(__name__)
-
-SATS_PER_BTC: int = 100_000_000
 
 
 def count_sats(

--- a/src/cryptoadvance/specterext/stacktrack/helpers/plot.py
+++ b/src/cryptoadvance/specterext/stacktrack/helpers/plot.py
@@ -2,6 +2,8 @@ import pandas as pd
 import plotly.graph_objects as go
 from plotly.offline import plot
 
+from .core import SATS_PER_BTC
+
 
 # TODO
 # - Use UTC
@@ -10,13 +12,13 @@ def plot_sats(df: pd.DataFrame, title: str) -> go.Figure:
     fig = go.Figure()
     fig.add_trace(go.Bar(
         x=df["timestamp"],
-        y=df["sats"],
+        y=df["sats"] / SATS_PER_BTC,
         name="BTC",
         marker={"color": "Green"},
     ))
     fig.add_trace(go.Scatter(
         x=df["timestamp"],
-        y=df["sats_cusum"],
+        y=df["sats_cusum"] / SATS_PER_BTC,
         name="Cumulative",
         mode="lines",
         line_shape="hv",


### PR DESCRIPTION
To minimize floating point errors, the DataFrame stores sats rather than btc. But (IMO anyway) the default chart display should be btc. This PR modifies the chart by transforming the sats into btc.

The y-axis label already said BTC, so I didn't need to change that.