### PR TITLE
wallet_overview extension

### DIFF
--- a/src/cryptoadvance/specterext/stacktrack/service.py
+++ b/src/cryptoadvance/specterext/stacktrack/service.py
@@ -7,6 +7,7 @@ from cryptoadvance.specter.services.service import Service, devstatus_alpha, dev
 # A SpecterError can be raised and will be shown to the user as a red banner
 from cryptoadvance.specter.specter_error import SpecterError
 from cryptoadvance.specter.wallet import Wallet
+from cryptoadvance.specter.server_endpoints.wallets.wallets_vm import WalletsOverviewVm
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,14 @@ class StacktrackService(Service):
             "endpoint": "stacktrack_wallet_chart",
         }]
 
+    def callback_adjust_view_model(self, view_model: WalletsOverviewVm):
+        if type(view_model) == WalletsOverviewVm:
+            # potentially, we could make a reidrect here:
+            # view_model.about_redirect=url_for("spectrum_endpoint.some_enpoint_here")
+            # but we do it small here and only replace a specific component:
+            view_model.tx_table_include  = "stacktrack/overview.jinja"
+
+        return view_model
     # There might be other callbacks you're interested in. Check the callbacks.py in the specter-desktop source.
     # if you are, create a method here which is "callback_" + callback_id
 

--- a/src/cryptoadvance/specterext/stacktrack/templates/stacktrack/overview.jinja
+++ b/src/cryptoadvance/specterext/stacktrack/templates/stacktrack/overview.jinja
@@ -1,0 +1,3 @@
+Hello Stacktrack. Here goes your Graph!
+
+{% include "wallet/overview/tx_table.jinja" %}


### PR DESCRIPTION
This adds the boilerplate code to extend the wallet_overview page.
This only works in combination with https://github.com/cryptoadvance/specter-desktop/pull/1913

![image](https://user-images.githubusercontent.com/117085/198122851-03d9fabe-add4-4551-a07c-2e5c674e0cf7.png)

You will need to pass additional parameters in order plot properly. In the individual template this gets rendered like this:
```python
    return render_template(
        "stacktrack/chart.jinja",
        wallet_alias=wallet_alias,
        wallet=wallet,
        ext_wallettabs=app.specter.service_manager.execute_ext_callbacks(callbacks.add_wallettabs),
        active_span=span,
        plot=balance_plot,
    )
```

So i'd simply add the necessary stuff to the `WalletsOverviewVm` object like:
```python
view_model.tx_table_include  = "stacktrack/overview.jinja"
view_model.active_span=span
view_model.plot=plot
```
The view_model is then available in your template like such:
```python
    return render_template(
        "wallet/overview/wallets_overview.jinja",
        specter=app.specter,
        rand=rand,
        services=app.specter.service_manager.services,
        wallets_overview_vm=wallets_overview_vm,
    )
```